### PR TITLE
Add first yml file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ['**']
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,123 @@
+name: CI
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    branches: [main]
+
+jobs:
+  build_test:
+    name: Build & Test Matrix
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: [gcc-13, clang-17]
+        build_type: [Debug, Release]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build ccache
+          if [ "${{ matrix.compiler }}" = "gcc-13" ]; then
+            sudo apt-get install -y gcc-13 g++-13
+          else
+            sudo apt-get install -y clang-17
+          fi
+
+      - name: Cache ccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.ccache
+          key: ${{ runner.os }}-ccache-${{ matrix.compiler }}-${{ matrix.build_type }}-${{ hashFiles('**/CMakeLists.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-ccache-${{ matrix.compiler }}-${{ matrix.build_type }}-
+            ${{ runner.os }}-ccache-${{ matrix.compiler }}-
+
+      - name: Configure
+        run: |
+          mkdir -p build
+          if [ "${{ matrix.compiler }}" = "gcc-13" ]; then
+            cmake -S . -B build -G Ninja \
+              -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+              -DCPUSCOPE_BUILD_TESTS=ON \
+              -DCPUSCOPE_WERROR=ON \
+              -DCMAKE_C_COMPILER=gcc-13 \
+              -DCMAKE_CXX_COMPILER=g++-13 \
+              -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          else
+            cmake -S . -B build -G Ninja \
+              -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+              -DCPUSCOPE_BUILD_TESTS=ON \
+              -DCPUSCOPE_WERROR=ON \
+              -DCMAKE_C_COMPILER=clang-17 \
+              -DCMAKE_CXX_COMPILER=clang++-17 \
+              -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          fi
+
+      - name: Build
+        run: cmake --build build --parallel
+
+      - name: Run tests
+        run: ctest --test-dir build --output-on-failure
+
+      - name: Smoke test
+        if: matrix.build_type == 'Release'
+        run: ./build/cpuscope_cli --version
+
+  lint:
+    name: Lint (Placeholder)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Placeholder lint
+        run: echo "Lint checks will be added later"
+
+  sanitizer:
+    name: Sanitizer Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build ccache clang-17
+
+      - name: Cache ccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.ccache
+          key: ${{ runner.os }}-ccache-clang-17-Release-${{ hashFiles('**/CMakeLists.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-ccache-clang-17-Release-
+            ${{ runner.os }}-ccache-clang-17-
+
+      - name: Configure sanitizer build
+        run: |
+          mkdir -p build-sanitizer
+          cmake -S . -B build-sanitizer -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCPUSCOPE_BUILD_TESTS=ON \
+            -DCPUSCOPE_WERROR=ON \
+            -DCMAKE_C_COMPILER=clang-17 \
+            -DCMAKE_CXX_COMPILER=clang++-17 \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_C_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=all" \
+            -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=all" \
+            -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined"
+
+      - name: Build sanitizer build
+        run: cmake --build build-sanitizer --parallel
+
+      - name: Run sanitizer tests
+        run: |
+          export ASAN_OPTIONS=halt_on_error=1:detect_leaks=0
+          export UBSAN_OPTIONS=halt_on_error=1
+          ctest --test-dir build-sanitizer --output-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,14 +45,18 @@ jobs:
               -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
               -DCPUSCOPE_BUILD_TESTS=ON \
               -DCPUSCOPE_WERROR=ON \
+              -DCMAKE_C_COMPILER=gcc-13 \
               -DCMAKE_CXX_COMPILER=g++-13 \
+              -DCMAKE_C_COMPILER_LAUNCHER=ccache \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           else
             cmake -S . -B build -G Ninja \
               -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
               -DCPUSCOPE_BUILD_TESTS=ON \
               -DCPUSCOPE_WERROR=ON \
+              -DCMAKE_C_COMPILER=clang-17 \
               -DCMAKE_CXX_COMPILER=clang++-17 \
+              -DCMAKE_C_COMPILER_LAUNCHER=ccache \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           fi
 
@@ -101,8 +105,11 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -DCPUSCOPE_BUILD_TESTS=ON \
             -DCPUSCOPE_WERROR=ON \
+            -DCMAKE_C_COMPILER=clang-17 \
             -DCMAKE_CXX_COMPILER=clang++-17 \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_C_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=all" \
             -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=all" \
             -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,18 +45,14 @@ jobs:
               -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
               -DCPUSCOPE_BUILD_TESTS=ON \
               -DCPUSCOPE_WERROR=ON \
-              -DCMAKE_C_COMPILER=gcc-13 \
               -DCMAKE_CXX_COMPILER=g++-13 \
-              -DCMAKE_C_COMPILER_LAUNCHER=ccache \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           else
             cmake -S . -B build -G Ninja \
               -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
               -DCPUSCOPE_BUILD_TESTS=ON \
               -DCPUSCOPE_WERROR=ON \
-              -DCMAKE_C_COMPILER=clang-17 \
               -DCMAKE_CXX_COMPILER=clang++-17 \
-              -DCMAKE_C_COMPILER_LAUNCHER=ccache \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           fi
 
@@ -105,11 +101,8 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -DCPUSCOPE_BUILD_TESTS=ON \
             -DCPUSCOPE_WERROR=ON \
-            -DCMAKE_C_COMPILER=clang-17 \
             -DCMAKE_CXX_COMPILER=clang++-17 \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_C_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=all" \
             -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=all" \
             -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
   message(FATAL_ERROR "In-source builds are not allowed. Please use a separate build directory.")
 endif()
 
-option(CI "Enable CI build mode and treat warnings as errors" OFF)
+option(CPUSCOPE_WERROR "Enable CI build mode and treat warnings as errors" OFF)
 option(ENABLE_MARCH_NATIVE "Enable -march=native optimization" OFF)
 option(CPUSCOPE_BUILD_TESTS "Build tests" OFF)
 
@@ -20,7 +20,7 @@ endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
   add_compile_options(-Wall -Wextra -Wpedantic)
-  if(CI)
+  if(CPUSCOPE_WERROR)
     add_compile_options(-Werror)
   endif()
   if(ENABLE_MARCH_NATIVE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.25)
 
-project(cpuscope VERSION 0.1.0 LANGUAGES CXX)
+project(cpuscope VERSION 0.1.0 LANGUAGES C CXX)
 
 if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
   message(FATAL_ERROR "In-source builds are not allowed. Please use a separate build directory.")


### PR DESCRIPTION
Added the CI workflow and made the CMake root honors the new warning-as-error option.

What changed
* Created ci.yml
* Added CPUSCOPE_WERROR option to CMakeLists.txt
* Updated root CMake to enable -Werror when  CPUSCOPE_WERROR is ON